### PR TITLE
fix bug when http.Do return error

### DIFF
--- a/untils/Untils.go
+++ b/untils/Untils.go
@@ -40,11 +40,10 @@ func HttpGetRequest(strUrl string, mapParams map[string]string) string {
 
 	// 发出请求
 	response, err := httpClient.Do(request)
-	defer response.Body.Close()
 	if nil != err {
 		return err.Error()
 	}
-
+	defer response.Body.Close()
 	// 解析响应内容
 	body, err := ioutil.ReadAll(response.Body)
 	if nil != err {


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x82b3764]

goroutine 1 [running]:
github.com/huobiapi/REST-GO-demo/untils.HttpGetRequest(0x19c52210, 0x29, 0x19f8fd24, 0x0, 0x0)
	/home/lizhengxiang/goProgram/src/github.com/huobiapi/REST-GO-demo/untils/Untils.go:43 +0xe4
github.com/huobiapi/REST-GO-demo/untils.ApiKeyGet(0x19f8fd24, 0x83495bb, 0x14, 0x19f8fd24, 0x19f8fd40)
	/home/lizhengxiang/goProgram/src/github.com/huobiapi/REST-GO-demo/untils/Untils.go:119 +0x304
github.com/huobiapi/REST-GO-demo/services.GetAccounts(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/lizhengxiang/goProgram/src/github.com/huobiapi/REST-GO-demo/services/Market.go:189 +0xa4
github.com/huobiapi/REST-GO-demo/services.Balance()
